### PR TITLE
Chore: Properly set `requires-python` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ license = { text = "Apache-2.0" }
 authors = [
   { name = "Andreas Motl", email = "andreas.motl@panodata.org" },
 ]
-requires-python = ">=3.9"
+requires-python = "<3.12,>=3.9"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",


### PR DESCRIPTION
Mark project as not ready for Python 3.12, also in order to resolve GH-25.