### PR TITLE
Chore: Improve dependency definitions for mypy and ruff to use `~=`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,10 @@ dependencies = [
 develop = [
   "black<24",
   "munch<5",
-  "mypy==1.7.1",
+  "mypy~=1.7.1",
   "poethepoet<0.25",
   "pyproject-fmt<1.6",
-  "ruff==0.1.9",
+  "ruff~=0.1.9",
   "types-tabulate",
 ]
 release = [


### PR DESCRIPTION
## About

@henryiii suggested at https://github.com/daq-tools/node-blue/pull/31#issuecomment-1885576720 to use `~=` when pinning fixed-version dependencies. In this way, Dependabot and pyproject-fmt will interfere less.
